### PR TITLE
JPEG2000 Resolution

### DIFF
--- a/src/PIL/Jpeg2KImagePlugin.py
+++ b/src/PIL/Jpeg2KImagePlugin.py
@@ -215,6 +215,7 @@ def _parse_jp2_header(fp):
                     hres = _res_to_dpi(hrcn, hrcd, hrce)
                     vres = _res_to_dpi(vrcn, vrcd, vrce)
                     dpi = (hres, vres)
+                    break
 
     if size is None or mode is None:
         raise SyntaxError("Malformed JP2 header")

--- a/src/PIL/Jpeg2KImagePlugin.py
+++ b/src/PIL/Jpeg2KImagePlugin.py
@@ -33,12 +33,12 @@ class BoxReader:
         self.remaining_in_box = -1
 
     def _can_read(self, num_bytes):
+        if self.has_length and self.fp.tell() + num_bytes > self.length:
+            # Outside box: ensure we don't read past the known file length
+            return False
         if self.remaining_in_box >= 0:
             # Inside box contents: ensure read does not go past box boundaries
             return num_bytes <= self.remaining_in_box
-        elif self.has_length:
-            # Outside box: ensure we don't read past the known file length
-            return self.fp.tell() + num_bytes <= self.length
         else:
             return True  # No length known, just read
 

--- a/src/PIL/Jpeg2KImagePlugin.py
+++ b/src/PIL/Jpeg2KImagePlugin.py
@@ -131,11 +131,8 @@ def _res_to_dpi(num, denom, exp):
     """Convert JPEG2000's (numerator, denominator, exponent-base-10) resolution,
     calculated as (num / denom) * 10^exp and stored in dots per meter,
     to floating-point dots per inch."""
-    if num == 0 or denom == 0:
-        raise SyntaxError(
-            f"Invalid JP2 resolution information: ({num} / {denom}) * 10^{exp}"
-        )
-    return (254 * num * (10 ** exp)) / (10000 * denom)
+    if denom != 0:
+        return num / denom * (10 ** exp) * 0.0254
 
 
 def _parse_jp2_header(fp):


### PR DESCRIPTION
Suggestions for https://github.com/python-pillow/Pillow/pull/5568

- If DPI is invalid, ignore it rather than raising an error. For comparison, [a ZeroDivisionError is caught when handling the DPI in JpegImagePlugin](https://github.com/python-pillow/Pillow/blob/68c5f2dce11768e5334a97d17feb2a85a0fd0590/src/PIL/JpegImagePlugin.py#L171). Also rearranges the conversion to use 0.0254, [like PngImagePlugin.](https://github.com/python-pillow/Pillow/blob/68c5f2dce11768e5334a97d17feb2a85a0fd0590/src/PIL/PngImagePlugin.py#L503)
- `break` out of reading the "res " box after the DPI has been read from "resc"
- Prevent reading past end of file pointer even if box length allows it. File input is not necessarily correct.